### PR TITLE
Add replace confirmation for file import

### DIFF
--- a/webapp_security_checklist.html
+++ b/webapp_security_checklist.html
@@ -750,6 +750,13 @@ $("#exportCSV").addEventListener("click", () => {
 $("#fileInput").addEventListener("change", event => {
   const file = event.target.files[0];
   if (!file) return;
+  if (!confirm("Replace existing data?")) {
+    event.target.value = ""; // clear selection to allow re-import later
+    return; // user chose not to replace data
+  }
+  data = []; // reset existing data
+  localStorage.removeItem(STORAGE_KEY);
+  localStorage.removeItem(COLLAPSE_KEY);
   const reader = new FileReader();
   reader.onload = e => {
     try {


### PR DESCRIPTION
## Summary
- ask user to confirm replacing existing checklist data when importing
- clear saved data and localStorage keys before importing new file when confirmed

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/WebCheckSec/package.json')*

------
https://chatgpt.com/codex/tasks/task_b_68c666d27ed48321a97c641526fdfe55